### PR TITLE
fix: bump docker nvidia/cuda to 11.7.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.7.0-devel-ubuntu20.04
+FROM nvidia/cuda:11.7.1-devel-ubuntu20.04
 
 # NOTE: We need cuda devel to build DCNv2, but we don't necessarily need it to
 # run inference. This should probably become a multi-part build if we care about

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && \
 
 RUN pip install --upgrade pip wheel cython
 
+# As of matplotlib 3.8.0, Python3.8 is no longer supported, so install our pinned version
+RUN pip install matplotlib==3.7.1
+
 RUN apt update && \
     apt install -y --no-install-recommends \
     # install ros packages


### PR DESCRIPTION
Nvidia pulled the cuda:11.7.0 image from the dockerhub repo, so this needs to get bumped.